### PR TITLE
add meta-aws-release-tests

### DIFF
--- a/release-tests/README.md
+++ b/release-tests/README.md
@@ -1,0 +1,15 @@
+# info
+this tests are performed before doing the ff-merge for [meta-aws](https://github.com/aws4embeddedlinux/meta-aws) `release-next` to `release` branches
+
+in this stage there should be:
+* build all recipes for all supported architectures (4 x 3 = 12 builds!)
+* generating of ptest report for whole layer  (4 x 3 = 12 reports!)
+* generating of CVE report? (x reports?)
+* generating of SBOM info?
+
+# usage
+run
+
+`meta-aws-release-tests.sh`
+
+and have time, cpu and memory!

--- a/release-tests/meta-aws-release-tests.sh
+++ b/release-tests/meta-aws-release-tests.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+RELEASES="master langdale kirkstone dunfell"
+
+ARCHS="qemuarm qemuarm64 qemux86 qemux86-64"
+
+setup_config() {
+# keep indent!
+cat <<EOF >>$BUILDDIR/conf/local.conf
+# Required to disable KVM/hypervisor mode.
+QEMU_USE_KVM = ""
+
+# use slirp networking instead of TAP interface (require root rights)
+QEMU_USE_SLIRP = "1"
+TEST_SERVER_IP = "127.0.0.1"
+
+# this will specify what test should run when running testimage cmd - oeqa layer tests + ptests:
+# Ping and SSH are not required, but do help in debugging. ptest will discover all ptest packages.
+TEST_SUITES = " ping ssh ptest"
+
+# this will allow - running testimage cmd: bitbake core-image-minimal -c testimage
+IMAGE_CLASSES += "testimage"
+
+# PUT = package under test / this is set in auto.conf
+PUT ?= ""
+IMAGE_INSTALL:append = " ptest-runner ssh \${PUT}"
+
+INHERIT += "cve-check"
+include cve-extra-exclusions.inc
+
+# INHERIT += "create-spdx"
+# SPDX_PRETTY = "1"
+EOF
+}
+
+set +exuo pipefail
+
+for RELEASE in $RELEASES ; do
+
+    rm -rf yocto_$RELEASE
+    mkdir yocto_$RELEASE
+
+    cd yocto_$RELEASE/
+
+    git clone git://git.yoctoproject.org/poky -b  $RELEASE
+    git clone https://github.com/aws4embeddedlinux/meta-aws.git -b $RELEASE-next
+    git clone https://github.com/openembedded/meta-openembedded.git -b $RELEASE
+
+    source poky/oe-init-build-env build
+
+    # add necessary layers
+    bitbake-layers add-layer ../meta-openembedded/meta-oe
+    bitbake-layers add-layer ../meta-openembedded/meta-python
+    bitbake-layers add-layer ../meta-openembedded/meta-networking
+    bitbake-layers add-layer ../meta-aws
+
+    echo 'DL_DIR = "${TOPDIR}/../../downloads"' >> conf/local.conf
+    echo 'SSTATE_DIR ?= "${TOPDIR}/../../sstate-cache"' >> conf/local.conf
+
+    # setup build/local.conf
+    setup_config
+
+    # find all recipes in meta-aws
+
+    ALL_RECIPES=`find ../meta-aws -name *.bb -type f  | sed 's!.*/!!' | sed 's!.bb!!' | sed 's!_.*!!' | sort | uniq | sed -z 's/\n/ /g'`
+
+    # find all recipes having a ptest in meta-aws
+    ptest_recipes=`find ../meta-aws -name *.bb -type f -print | xargs grep -l 'inherit.*ptest.*'| sed 's!.*/!!' | sed 's!.bb!!' | sed 's!_.*!!' | sort | uniq | sed -z 's/\n/ /g'`
+
+    # make array out of string
+    ptest_recipes_array=($(echo "$ptest_recipes" | tr ',' '\n'))
+
+    # add -ptest suffix
+    ptest_recipes_names_array_with_ptest=("${ptest_recipes_array[@]/%/-ptest}")
+
+    # make string again
+    PTEST_RECIPE_NAMES_WITH_PTEST_SUFFIX="${ptest_recipes_names_array_with_ptest[@]}"
+
+    for ARCH in $ARCHS ; do
+
+        # build everything in meta-aws layer and save errors
+        MACHINE=$ARCH bitbake $ALL_RECIPES -k | tee -a ../../$RELEASE-$ARCH-build.log
+
+        # do ptests for all recipes having a ptest in meta-aws
+
+        echo PUT = \"${PTEST_RECIPE_NAMES_WITH_PTEST_SUFFIX}\" > $BUILDDIR/conf/auto.conf
+
+        MACHINE=$ARCH bitbake core-image-minimal
+
+        cp $BUILDDIR/tmp/log/cve/cve-summary.json ../../$RELEASE-$ARCH-cve-summary.json
+
+        MACHINE=$ARCH bitbake core-image-minimal -c testimage
+
+        rm  $BUILDDIR/conf/auto.conf
+
+        cp $BUILDDIR/tmp/log/oeqa/testresults.json ../../$RELEASE-$ARCH-testresults.json
+
+        # show results
+        resulttool report $BUILDDIR/tmp/log/oeqa/testresults.json
+
+        cd ../
+
+    done
+done


### PR DESCRIPTION
this bash script is used to test meta-aws before doing a ff-merge from release-next to release branches