### PR TITLE
feat: add backporter tool for recipe version upgrades to release branches

### DIFF
--- a/auto-upgrader/tests/test_proc.py
+++ b/auto-upgrader/tests/test_proc.py
@@ -2,7 +2,7 @@ from upgrader import proc
 
 
 def test_async_run() -> None:
-    (so, se, rc) = proc.run("echo test; sleep 2; echo test2;exit 1")
+    so, se, rc = proc.run("echo test; sleep 2; echo test2;exit 1")
     assert so == "test\ntest2"
     assert se == ""
     assert rc == 1

--- a/auto-upgrader/upgrader/proc.py
+++ b/auto-upgrader/upgrader/proc.py
@@ -1,4 +1,5 @@
 """Helpers for running processes."""
+
 import asyncio
 import logging
 from asyncio.subprocess import PIPE

--- a/auto-upgrader/upgrader/updates.py
+++ b/auto-upgrader/upgrader/updates.py
@@ -70,7 +70,7 @@ def check_for_updates(recipe: str) -> bool:
 
 
 def _check_for_updates(recipe: str) -> Optional[dict]:
-    (stdout, _, _) = run(f"devtool check-upgrade-status {recipe}")
+    stdout, _, _ = run(f"devtool check-upgrade-status {recipe}")
     update_re = recipe + r"\s+([^\s]+)\s+([^\s]+)"
     m = re.search(update_re, stdout)
     if m:
@@ -135,7 +135,7 @@ def update(layer_path: Path, target_branch: str) -> None:
         run(f"git -C {layer_path} checkout {target_branch}")
 
         # Attempt upgrade
-        (_, _, ret) = run(f"devtool upgrade {upgrade.get('recipe')}")
+        _, _, ret = run(f"devtool upgrade {upgrade.get('recipe')}")
         if ret != 0:
             logger.warn(
                 f"upgrading {upgrade.get('recipe')} failed. return code was {ret}"
@@ -152,7 +152,7 @@ def update(layer_path: Path, target_branch: str) -> None:
         run(f"git -C {layer_path} checkout -b {new_branch} {target_branch}")
 
         # Finalize recipe
-        (_, _, ret) = run(
+        _, _, ret = run(
             f"devtool finish --force --force-patch-refresh {upgrade.get('recipe')} {layer_path}"
         )
         if ret != 0:

--- a/backporter/auto-backport.yml
+++ b/backporter/auto-backport.yml
@@ -1,0 +1,146 @@
+name: auto-backport
+
+on:
+  pull_request_target:
+    branches:
+      - master-next
+    types: ["closed"]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  backport:
+    name: Backport to release branches
+    runs-on: ubuntu-22.04
+    # Only run when pull request is merged and labeled 'version-upgrade' or 'auto-backport'
+    if: (github.event.pull_request.merged == true) &&
+        (contains(github.event.pull_request.labels.*.name, 'version-upgrade') || contains(github.event.pull_request.labels.*.name, 'auto-backport'))
+    steps:
+      - name: Checkout meta-aws
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.MAINTAINER_TOKEN }}
+
+      - name: Checkout meta-aws-ci
+        uses: actions/checkout@v4
+        with:
+          repository: aws4embeddedlinux/meta-aws-ci
+          ref: master
+          path: ci
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install backporter
+        run: pip install ./ci/backporter
+
+      - name: Configure git
+        run: |
+          git config user.name meta-aws-maintainer
+          git config user.email meta-aws-maintainer@users.noreply.github.com
+
+      - name: Parse merged commit
+        id: parse
+        env:
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          echo "Parsing merge commit: $MERGE_SHA"
+          OUTPUT=$(backporter parse-commit --commit "$MERGE_SHA" --layer-path .)
+          if [ $? -ne 0 ] || [ -z "$OUTPUT" ]; then
+            echo "Could not parse upgrade info from commit. Skipping backport."
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "$OUTPUT"
+          echo "data=$OUTPUT" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+
+      - name: Backport to release branches
+        if: steps.parse.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.MAINTAINER_TOKEN }}
+          PARSE_DATA: ${{ steps.parse.outputs.data }}
+        run: |
+          set -e
+
+          RECIPE=$(echo "$PARSE_DATA" | jq -r '.recipe')
+          VERSION=$(echo "$PARSE_DATA" | jq -r '.version')
+          SRCREV=$(echo "$PARSE_DATA" | jq -r '.srcrev // empty')
+          SHA256SUMS=$(echo "$PARSE_DATA" | jq -r '.sha256sums // empty')
+
+          echo "Recipe: $RECIPE"
+          echo "Version: $VERSION"
+          echo "SRCREV: $SRCREV"
+          echo "SHA256SUMS: $SHA256SUMS"
+
+          TARGET_BRANCHES=("scarthgap-next" "whinlatter-next" "wrynose-next")
+
+          for branch in "${TARGET_BRANCHES[@]}"; do
+            echo ""
+            echo "========================================="
+            echo "Backporting $RECIPE $VERSION to $branch"
+            echo "========================================="
+
+            # Build the backporter command
+            CMD="backporter upgrade --recipe $RECIPE --version $VERSION --target-branch $branch --layer-path ."
+
+            if [ -n "$SRCREV" ]; then
+              CMD="$CMD --srcrev $SRCREV"
+            elif [ -n "$SHA256SUMS" ]; then
+              # Build --sha256sum flags from JSON object
+              while IFS='=' read -r key value; do
+                CMD="$CMD --sha256sum $key=$value"
+              done < <(echo "$SHA256SUMS" | jq -r 'to_entries[] | "\(.key)=\(.value)"')
+            else
+              echo "ERROR: No SRCREV or sha256sums found. Skipping $branch."
+              continue
+            fi
+
+            # Run the backporter
+            OUTPUT=$(eval $CMD 2>&1)
+            EXIT_CODE=$?
+            echo "$OUTPUT"
+
+            # Check if it was a skip (exit 0 but no branch created) or success
+            if echo "$OUTPUT" | grep -q "^⊘"; then
+              echo "Skipped: $branch"
+              git checkout master-next 2>/dev/null || true
+              continue
+            fi
+
+            if [ $EXIT_CODE -ne 0 ]; then
+              echo "ERROR: Backporter failed for $branch. Continuing."
+              git checkout master-next 2>/dev/null || true
+              continue
+            fi
+
+            # Get the branch name that was created
+            BACKPORT_BRANCH="backport/${RECIPE}_${VERSION}_to_${branch}"
+
+            # Push the branch
+            git push origin "$BACKPORT_BRANCH" --force
+
+            # Create the PR
+            gh pr create \
+              --repo "${{ github.repository }}" \
+              --base "$branch" \
+              --head "$BACKPORT_BRANCH" \
+              --title "$RECIPE: upgrade to $VERSION" \
+              --body "Automated backport from master-next PR #${{ github.event.pull_request.number }}.
+
+              Recipe: \`$RECIPE\`
+              Version: \`$VERSION\`
+              Source PR: #${{ github.event.pull_request.number }}" \
+              --label "version-upgrade" || {
+                echo "PR creation failed (may already exist). Continuing."
+              }
+
+            # Return to master-next for the next iteration
+            git checkout master-next
+          done
+
+          echo ""
+          echo "Backport complete."

--- a/backporter/backporter/__init__.py
+++ b/backporter/backporter/__init__.py
@@ -1,0 +1,3 @@
+"""Backporter: upgrade recipe versions on release branches via git mv + hash update."""
+
+__version__ = "0.1.0"

--- a/backporter/backporter/cli.py
+++ b/backporter/backporter/cli.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Optional
 
 import click
-
 from backporter.core import BackportInput, backport
 
 logger = logging.getLogger("backporter")
@@ -25,9 +24,13 @@ def cli(verbose: bool) -> None:
 
 
 @cli.command()
-@click.option("--recipe", required=True, help="Recipe name (PN), e.g. 'python3-botocore'.")
+@click.option(
+    "--recipe", required=True, help="Recipe name (PN), e.g. 'python3-botocore'."
+)
 @click.option("--version", required=True, help="New version to upgrade to.")
-@click.option("--target-branch", required=True, help="Branch to backport to, e.g. 'wrynose-next'.")
+@click.option(
+    "--target-branch", required=True, help="Branch to backport to, e.g. 'wrynose-next'."
+)
 @click.option("--srcrev", default=None, help="New SRCREV hash (for git-based recipes).")
 @click.option(
     "--sha256sum",
@@ -40,7 +43,9 @@ def cli(verbose: bool) -> None:
     required=True,
     help="Path to the layer git repository.",
 )
-@click.option("--push/--no-push", default=False, help="Push the branch to origin after commit.")
+@click.option(
+    "--push/--no-push", default=False, help="Push the branch to origin after commit."
+)
 def upgrade(
     recipe: str,
     version: str,
@@ -71,7 +76,10 @@ def upgrade(
     sha256sums = {}
     for entry in sha256sum:
         if "=" not in entry:
-            click.echo(f"ERROR: --sha256sum must be in 'name=hash' format, got: {entry}", err=True)
+            click.echo(
+                f"ERROR: --sha256sum must be in 'name=hash' format, got: {entry}",
+                err=True,
+            )
             sys.exit(1)
         name, hash_value = entry.split("=", 1)
         sha256sums[name] = hash_value
@@ -109,7 +117,8 @@ def upgrade(
         click.echo(f"⊘ {result.message}")
         sys.exit(
             0
-            if "not found" in result.message.lower() or "skipping" in result.message.lower()
+            if "not found" in result.message.lower()
+            or "skipping" in result.message.lower()
             else 1
         )
 

--- a/backporter/backporter/cli.py
+++ b/backporter/backporter/cli.py
@@ -107,7 +107,11 @@ def upgrade(
                 sys.exit(1)
     else:
         click.echo(f"⊘ {result.message}")
-        sys.exit(0 if "not found" in result.message.lower() or "skipping" in result.message.lower() else 1)
+        sys.exit(
+            0
+            if "not found" in result.message.lower() or "skipping" in result.message.lower()
+            else 1
+        )
 
 
 @cli.command()

--- a/backporter/backporter/cli.py
+++ b/backporter/backporter/cli.py
@@ -1,0 +1,144 @@
+"""CLI interface for the backporter tool."""
+
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from backporter.core import BackportInput, backport
+
+logger = logging.getLogger("backporter")
+
+
+@click.group()
+@click.option("--verbose", "-v", is_flag=True, help="Enable verbose output.")
+def cli(verbose: bool) -> None:
+    """Backport recipe version upgrades to release branches."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(levelname)s: %(message)s",
+    )
+
+
+@cli.command()
+@click.option("--recipe", required=True, help="Recipe name (PN), e.g. 'python3-botocore'.")
+@click.option("--version", required=True, help="New version to upgrade to.")
+@click.option("--target-branch", required=True, help="Branch to backport to, e.g. 'wrynose-next'.")
+@click.option("--srcrev", default=None, help="New SRCREV hash (for git-based recipes).")
+@click.option(
+    "--sha256sum",
+    multiple=True,
+    help="sha256sum in 'name=hash' format (repeatable). E.g. --sha256sum x86-64=abc123",
+)
+@click.option(
+    "--layer-path",
+    type=click.Path(exists=True),
+    required=True,
+    help="Path to the layer git repository.",
+)
+@click.option("--push/--no-push", default=False, help="Push the branch to origin after commit.")
+def upgrade(
+    recipe: str,
+    version: str,
+    target_branch: str,
+    srcrev: Optional[str],
+    sha256sum: tuple,
+    layer_path: str,
+    push: bool,
+) -> None:
+    """
+    Backport a single recipe version upgrade to a target branch.
+
+    Either --srcrev or one or more --sha256sum must be provided.
+
+    Examples:
+
+        # SRCREV-based recipe
+        backporter upgrade --recipe python3-botocore --version 1.43.55 \\
+            --srcrev b71d5637f58df4bc61953b80902b3c040c7af889 \\
+            --target-branch wrynose-next --layer-path ./meta-aws
+
+        # sha256sum-based recipe (multiple architectures)
+        backporter upgrade --recipe corretto-21-bin --version 21.0.11.10.1 \\
+            --sha256sum "x86-64=1d03a3bd..." --sha256sum "aarch64=90a07c1c..." \\
+            --target-branch scarthgap-next --layer-path ./meta-aws
+    """
+    # Parse sha256sums
+    sha256sums = {}
+    for entry in sha256sum:
+        if "=" not in entry:
+            click.echo(f"ERROR: --sha256sum must be in 'name=hash' format, got: {entry}", err=True)
+            sys.exit(1)
+        name, hash_value = entry.split("=", 1)
+        sha256sums[name] = hash_value
+
+    # Validate that we have either srcrev or sha256sums
+    if not srcrev and not sha256sums:
+        click.echo("ERROR: Either --srcrev or --sha256sum must be provided.", err=True)
+        sys.exit(1)
+
+    input = BackportInput(
+        recipe=recipe,
+        version=version,
+        target_branch=target_branch,
+        srcrev=srcrev,
+        sha256sums=sha256sums,
+    )
+
+    path = Path(layer_path)
+    result = backport(path, input)
+
+    if result.success:
+        click.echo(f"✓ {result.message}")
+        click.echo(f"  Branch: {result.branch_name}")
+
+        if push:
+            from backporter.core import run_git
+
+            try:
+                run_git(["push", "-u", "origin", result.branch_name], cwd=path)
+                click.echo(f"  Pushed to origin/{result.branch_name}")
+            except Exception as e:
+                click.echo(f"  WARNING: Push failed: {e}", err=True)
+                sys.exit(1)
+    else:
+        click.echo(f"⊘ {result.message}")
+        sys.exit(0 if "not found" in result.message.lower() or "skipping" in result.message.lower() else 1)
+
+
+@cli.command()
+@click.option(
+    "--commit",
+    required=True,
+    help="Git commit SHA or ref to extract upgrade info from.",
+)
+@click.option(
+    "--layer-path",
+    type=click.Path(exists=True),
+    required=True,
+    help="Path to the layer git repository.",
+)
+def parse_commit(commit: str, layer_path: str) -> None:
+    """
+    Parse a merged upgrade commit and output the recipe, version, and hashes as JSON.
+
+    Useful for extracting backport inputs from a master-next merge event.
+    """
+    from backporter.parser import parse_upgrade_commit
+
+    path = Path(layer_path)
+    result = parse_upgrade_commit(path, commit)
+
+    if result is None:
+        click.echo("ERROR: Could not parse upgrade info from commit.", err=True)
+        sys.exit(1)
+
+    click.echo(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    cli()

--- a/backporter/backporter/core.py
+++ b/backporter/backporter/core.py
@@ -256,7 +256,11 @@ def backport(layer_path: Path, input: BackportInput) -> BackportResult:
     # git mv
     try:
         run_git(
-            ["mv", str(recipe_path.relative_to(layer_path)), str(new_path.relative_to(layer_path))],
+            [
+                "mv",
+                str(recipe_path.relative_to(layer_path)),
+                str(new_path.relative_to(layer_path)),
+            ],
             cwd=layer_path,
         )
     except subprocess.CalledProcessError as e:

--- a/backporter/backporter/core.py
+++ b/backporter/backporter/core.py
@@ -1,0 +1,316 @@
+"""Core logic for backporting recipe version upgrades."""
+
+import logging
+import os
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+RECIPE_NAME_RE = re.compile(r"^(?P<name>[^_]+)_(?P<version>.+)\.bb$")
+SRCREV_RE = re.compile(r'^(SRCREV\s*=\s*")([^"]+)(")', re.MULTILINE)
+SHA256SUM_RE = re.compile(
+    r'^(SRC_URI\[(?P<name>[^\]]+)\.sha256sum\]\s*=\s*")([0-9a-f]+)(")', re.MULTILINE
+)
+
+
+@dataclass
+class BackportResult:
+    """Result of a backport operation."""
+
+    recipe: str
+    target_branch: str
+    success: bool
+    old_version: Optional[str] = None
+    new_version: Optional[str] = None
+    branch_name: Optional[str] = None
+    message: str = ""
+
+
+@dataclass
+class BackportInput:
+    """Input parameters for a backport operation."""
+
+    recipe: str
+    version: str
+    target_branch: str
+    srcrev: Optional[str] = None
+    sha256sums: Dict[str, str] = field(default_factory=dict)
+
+
+def find_recipe_file(layer_path: Path, recipe: str) -> Optional[Path]:
+    """
+    Find the current .bb file for a recipe in the layer.
+
+    Searches recursively for a file matching `{recipe}_*.bb`.
+
+    Parameters
+    ----------
+    layer_path : Path
+        Root of the Yocto layer.
+    recipe : str
+        Recipe name (PN), e.g. "python3-botocore".
+
+    Returns
+    -------
+    Optional[Path]
+        Path to the recipe file, or None if not found.
+    """
+    for root, _, files in os.walk(layer_path):
+        for fname in files:
+            m = RECIPE_NAME_RE.match(fname)
+            if m and m.group("name") == recipe:
+                return Path(root) / fname
+    return None
+
+
+def get_recipe_version(recipe_path: Path) -> Optional[str]:
+    """
+    Extract the version from a recipe filename.
+
+    Parameters
+    ----------
+    recipe_path : Path
+        Path to the .bb file.
+
+    Returns
+    -------
+    Optional[str]
+        The version string, or None if it can't be parsed.
+    """
+    m = RECIPE_NAME_RE.match(recipe_path.name)
+    if m:
+        return m.group("version")
+    return None
+
+
+def update_srcrev(content: str, new_srcrev: str) -> str:
+    """
+    Replace the SRCREV value in recipe content.
+
+    Parameters
+    ----------
+    content : str
+        The recipe file content.
+    new_srcrev : str
+        The new SRCREV hash.
+
+    Returns
+    -------
+    str
+        Updated content.
+    """
+    new_content, count = SRCREV_RE.subn(rf"\g<1>{new_srcrev}\3", content)
+    if count == 0:
+        logger.warning("No SRCREV found in recipe content")
+    else:
+        logger.info(f"Updated {count} SRCREV occurrence(s)")
+    return new_content
+
+
+def update_sha256sums(content: str, sha256sums: Dict[str, str]) -> str:
+    """
+    Replace SRC_URI[name.sha256sum] values in recipe content.
+
+    Parameters
+    ----------
+    content : str
+        The recipe file content.
+    sha256sums : Dict[str, str]
+        Mapping of arch/name to new sha256sum, e.g. {"x86-64": "abc...", "aarch64": "def..."}.
+
+    Returns
+    -------
+    str
+        Updated content.
+    """
+    for name, new_hash in sha256sums.items():
+        pattern = re.compile(
+            rf'^(SRC_URI\[{re.escape(name)}\.sha256sum\]\s*=\s*")([0-9a-f]+)(")',
+            re.MULTILINE,
+        )
+        new_content, count = pattern.subn(rf"\g<1>{new_hash}\3", content)
+        if count == 0:
+            logger.warning(f"No SRC_URI[{name}.sha256sum] found in recipe content")
+        else:
+            logger.info(f"Updated SRC_URI[{name}.sha256sum]")
+            content = new_content
+    return content
+
+
+def run_git(args: List[str], cwd: Path) -> subprocess.CompletedProcess:
+    """
+    Run a git command.
+
+    Parameters
+    ----------
+    args : List[str]
+        Git subcommand and arguments.
+    cwd : Path
+        Working directory.
+
+    Returns
+    -------
+    subprocess.CompletedProcess
+        The completed process result.
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If the git command fails.
+    """
+    cmd = ["git"] + args
+    logger.debug(f"Running: {' '.join(cmd)} (cwd={cwd})")
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=True)
+
+
+def backport(layer_path: Path, input: BackportInput) -> BackportResult:
+    """
+    Perform a recipe version backport on a target branch.
+
+    This function:
+    1. Checks out the target branch
+    2. Finds the current recipe file
+    3. Renames it (git mv) to the new version
+    4. Updates SRCREV or sha256sum(s)
+    5. Commits the change
+
+    Parameters
+    ----------
+    layer_path : Path
+        Path to the layer git repository.
+    input : BackportInput
+        The backport parameters.
+
+    Returns
+    -------
+    BackportResult
+        The result of the operation.
+    """
+    recipe = input.recipe
+    new_version = input.version
+    target_branch = input.target_branch
+
+    # Checkout the target branch
+    try:
+        run_git(["checkout", target_branch], cwd=layer_path)
+    except subprocess.CalledProcessError as e:
+        return BackportResult(
+            recipe=recipe,
+            target_branch=target_branch,
+            success=False,
+            message=f"Failed to checkout branch '{target_branch}': {e.stderr.strip()}",
+        )
+
+    # Find the current recipe file
+    recipe_path = find_recipe_file(layer_path, recipe)
+    if recipe_path is None:
+        return BackportResult(
+            recipe=recipe,
+            target_branch=target_branch,
+            success=False,
+            message=f"Recipe '{recipe}' not found on branch '{target_branch}'. Skipping.",
+        )
+
+    old_version = get_recipe_version(recipe_path)
+    if old_version is None:
+        return BackportResult(
+            recipe=recipe,
+            target_branch=target_branch,
+            success=False,
+            message=f"Could not parse version from '{recipe_path.name}'.",
+        )
+
+    # Skip if already at or ahead of target version
+    if old_version == new_version:
+        return BackportResult(
+            recipe=recipe,
+            target_branch=target_branch,
+            success=False,
+            old_version=old_version,
+            new_version=new_version,
+            message=f"Recipe already at version {new_version}. Skipping.",
+        )
+
+    # Create a new branch for the backport
+    branch_name = f"backport/{recipe}_{new_version}_to_{target_branch}"
+    try:
+        run_git(["checkout", "-b", branch_name], cwd=layer_path)
+    except subprocess.CalledProcessError as e:
+        return BackportResult(
+            recipe=recipe,
+            target_branch=target_branch,
+            success=False,
+            old_version=old_version,
+            new_version=new_version,
+            message=f"Failed to create branch '{branch_name}': {e.stderr.strip()}",
+        )
+
+    # Compute new file path
+    new_filename = f"{recipe}_{new_version}.bb"
+    new_path = recipe_path.parent / new_filename
+
+    # git mv
+    try:
+        run_git(
+            ["mv", str(recipe_path.relative_to(layer_path)), str(new_path.relative_to(layer_path))],
+            cwd=layer_path,
+        )
+    except subprocess.CalledProcessError as e:
+        return BackportResult(
+            recipe=recipe,
+            target_branch=target_branch,
+            success=False,
+            old_version=old_version,
+            new_version=new_version,
+            message=f"git mv failed: {e.stderr.strip()}",
+        )
+
+    # Read the file content and update hashes
+    content = new_path.read_text()
+
+    if input.srcrev:
+        content = update_srcrev(content, input.srcrev)
+    elif input.sha256sums:
+        content = update_sha256sums(content, input.sha256sums)
+    else:
+        return BackportResult(
+            recipe=recipe,
+            target_branch=target_branch,
+            success=False,
+            old_version=old_version,
+            new_version=new_version,
+            message="No SRCREV or sha256sums provided. Cannot update hashes.",
+        )
+
+    # Write updated content
+    new_path.write_text(content)
+
+    # Stage and commit
+    run_git(["add", "--all"], cwd=layer_path)
+
+    commit_msg = f"{recipe}: upgrade {old_version} -> {new_version}"
+    try:
+        run_git(["commit", "-m", commit_msg], cwd=layer_path)
+    except subprocess.CalledProcessError as e:
+        return BackportResult(
+            recipe=recipe,
+            target_branch=target_branch,
+            success=False,
+            old_version=old_version,
+            new_version=new_version,
+            message=f"git commit failed: {e.stderr.strip()}",
+        )
+
+    return BackportResult(
+        recipe=recipe,
+        target_branch=target_branch,
+        success=True,
+        old_version=old_version,
+        new_version=new_version,
+        branch_name=branch_name,
+        message=f"Successfully backported {recipe} {old_version} -> {new_version}",
+    )

--- a/backporter/backporter/parser.py
+++ b/backporter/backporter/parser.py
@@ -18,7 +18,8 @@ SRCREV_DIFF_RE = re.compile(r'^\+SRCREV\s*=\s*"([0-9a-f]+)"', re.MULTILINE)
 
 # Matches SRC_URI[name.sha256sum] changes in diffs
 SHA256SUM_DIFF_RE = re.compile(
-    r'^\+SRC_URI\[(?P<name>[^\]]+)\.sha256sum\]\s*=\s*"(?P<hash>[0-9a-f]+)"', re.MULTILINE
+    r'^\+SRC_URI\[(?P<name>[^\]]+)\.sha256sum\]\s*=\s*"(?P<hash>[0-9a-f]+)"',
+    re.MULTILINE,
 )
 
 

--- a/backporter/backporter/parser.py
+++ b/backporter/backporter/parser.py
@@ -1,0 +1,100 @@
+"""Parse merged upgrade commits to extract backport inputs."""
+
+import logging
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Matches commit messages like: "python3-botocore: upgrade 1.43.53 -> 1.43.55"
+COMMIT_MSG_RE = re.compile(
+    r"^(?P<recipe>[^:]+):\s+upgrade\s+(?P<old_version>\S+)\s*->\s*(?P<new_version>\S+)"
+)
+
+# Matches SRCREV changes in diffs
+SRCREV_DIFF_RE = re.compile(r'^\+SRCREV\s*=\s*"([0-9a-f]+)"', re.MULTILINE)
+
+# Matches SRC_URI[name.sha256sum] changes in diffs
+SHA256SUM_DIFF_RE = re.compile(
+    r'^\+SRC_URI\[(?P<name>[^\]]+)\.sha256sum\]\s*=\s*"(?P<hash>[0-9a-f]+)"', re.MULTILINE
+)
+
+
+def parse_upgrade_commit(layer_path: Path, commit_ref: str) -> Optional[Dict[str, Any]]:
+    """
+    Parse a commit to extract recipe upgrade information.
+
+    Parameters
+    ----------
+    layer_path : Path
+        Path to the git repository.
+    commit_ref : str
+        Git commit reference (SHA, branch, HEAD, etc.).
+
+    Returns
+    -------
+    Optional[Dict[str, Any]]
+        Dictionary with keys: recipe, version, srcrev (or sha256sums), old_version.
+        Returns None if the commit is not a parseable upgrade.
+    """
+    # Get commit message
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%s", commit_ref],
+            cwd=layer_path,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        logger.error(f"Failed to read commit {commit_ref}")
+        return None
+
+    message = result.stdout.strip()
+    m = COMMIT_MSG_RE.match(message)
+    if not m:
+        logger.info(f"Commit message does not match upgrade pattern: {message}")
+        return None
+
+    recipe = m.group("recipe")
+    old_version = m.group("old_version")
+    new_version = m.group("new_version")
+
+    # Get the diff to extract new hashes
+    try:
+        result = subprocess.run(
+            ["git", "show", commit_ref, "--", "*.bb"],
+            cwd=layer_path,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        logger.error(f"Failed to get diff for commit {commit_ref}")
+        return None
+
+    diff = result.stdout
+
+    # Try to find SRCREV
+    srcrev_match = SRCREV_DIFF_RE.search(diff)
+
+    # Try to find sha256sums
+    sha256sum_matches = SHA256SUM_DIFF_RE.findall(diff)
+
+    output: Dict[str, Any] = {
+        "recipe": recipe,
+        "version": new_version,
+        "old_version": old_version,
+    }
+
+    if srcrev_match:
+        output["srcrev"] = srcrev_match.group(1)
+    elif sha256sum_matches:
+        output["sha256sums"] = {name: hash_val for name, hash_val in sha256sum_matches}
+    else:
+        logger.warning(f"No SRCREV or sha256sum found in diff for {recipe}")
+        return None
+
+    return output

--- a/backporter/pyproject.toml
+++ b/backporter/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "backporter"
+version = "0.1.0"
+description = "Backport recipe version upgrades to release branches via git mv + hash update"
+license = "MIT-0"
+authors = [
+    { name = "Rich Elberger", email = "elberger@amazon.com" },
+]
+requires-python = ">=3.9"
+dependencies = [
+    "click>=8.1.0",
+]
+
+[project.scripts]
+backporter = "backporter.cli:cli"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 100
+
+[tool.isort]
+profile = "black"
+line_length = 100
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/backporter/tests/test_backporter.py
+++ b/backporter/tests/test_backporter.py
@@ -1,6 +1,5 @@
 """Tests for the backporter tool."""
 
-import os
 import subprocess
 from pathlib import Path
 

--- a/backporter/tests/test_backporter.py
+++ b/backporter/tests/test_backporter.py
@@ -60,8 +60,10 @@ def git_layer_sha256(tmp_path):
     recipe_file = recipes_dir / "corretto-21-bin_21.0.10.9.1.bb"
     recipe_file.write_text(
         'SUMMARY = "Amazon Corretto 21"\n'
-        'SRC_URI:append:aarch64 = " https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-linux-aarch64.tar.gz;name=aarch64"\n'
-        'SRC_URI:append:x86-64 = " https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-linux-x64.tar.gz;name=x86-64"\n'
+        'SRC_URI:append:aarch64 = " https://corretto.aws/downloads/resources/'
+        '${PV}/amazon-corretto-${PV}-linux-aarch64.tar.gz;name=aarch64"\n'
+        'SRC_URI:append:x86-64 = " https://corretto.aws/downloads/resources/'
+        '${PV}/amazon-corretto-${PV}-linux-x64.tar.gz;name=x86-64"\n'
         'SRC_URI[x86-64.sha256sum] = "aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111"\n'
         'SRC_URI[aarch64.sha256sum] = "bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222"\n'
         "require corretto-bin-common.inc\n"
@@ -120,8 +122,8 @@ class TestUpdateSrcrev:
 class TestUpdateSha256sums:
     def test_replaces_sha256sums(self):
         content = (
-            'SRC_URI[x86-64.sha256sum] = "aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111"\n'
-            'SRC_URI[aarch64.sha256sum] = "bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222"\n'
+            'SRC_URI[x86-64.sha256sum] = "aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111"\n'  # noqa: E501
+            'SRC_URI[aarch64.sha256sum] = "bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222"\n'  # noqa: E501
         )
         result = update_sha256sums(
             content,

--- a/backporter/tests/test_backporter.py
+++ b/backporter/tests/test_backporter.py
@@ -43,9 +43,7 @@ def git_layer(tmp_path):
         ["git", "config", "user.name", "Test"], cwd=layer, capture_output=True, check=True
     )
     subprocess.run(["git", "add", "--all"], cwd=layer, capture_output=True, check=True)
-    subprocess.run(
-        ["git", "commit", "-m", "initial"], cwd=layer, capture_output=True, check=True
-    )
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=layer, capture_output=True, check=True)
     subprocess.run(
         ["git", "branch", "-M", "wrynose-next"], cwd=layer, capture_output=True, check=True
     )
@@ -78,9 +76,7 @@ def git_layer_sha256(tmp_path):
         ["git", "config", "user.name", "Test"], cwd=layer, capture_output=True, check=True
     )
     subprocess.run(["git", "add", "--all"], cwd=layer, capture_output=True, check=True)
-    subprocess.run(
-        ["git", "commit", "-m", "initial"], cwd=layer, capture_output=True, check=True
-    )
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=layer, capture_output=True, check=True)
     subprocess.run(
         ["git", "branch", "-M", "scarthgap-next"], cwd=layer, capture_output=True, check=True
     )
@@ -117,7 +113,7 @@ class TestUpdateSrcrev:
         assert "oldoldold" not in result
 
     def test_no_srcrev(self):
-        content = "SUMMARY = \"test\"\n"
+        content = 'SUMMARY = "test"\n'
         result = update_srcrev(content, "abc123")
         assert result == content
 

--- a/backporter/tests/test_backporter.py
+++ b/backporter/tests/test_backporter.py
@@ -4,7 +4,6 @@ import subprocess
 from pathlib import Path
 
 import pytest
-
 from backporter.core import (
     BackportInput,
     backport,
@@ -36,15 +35,26 @@ def git_layer(tmp_path):
     # Initialize git repo
     subprocess.run(["git", "init"], cwd=layer, capture_output=True, check=True)
     subprocess.run(
-        ["git", "config", "user.email", "test@test.com"], cwd=layer, capture_output=True, check=True
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=layer,
+        capture_output=True,
+        check=True,
     )
     subprocess.run(
-        ["git", "config", "user.name", "Test"], cwd=layer, capture_output=True, check=True
+        ["git", "config", "user.name", "Test"],
+        cwd=layer,
+        capture_output=True,
+        check=True,
     )
     subprocess.run(["git", "add", "--all"], cwd=layer, capture_output=True, check=True)
-    subprocess.run(["git", "commit", "-m", "initial"], cwd=layer, capture_output=True, check=True)
     subprocess.run(
-        ["git", "branch", "-M", "wrynose-next"], cwd=layer, capture_output=True, check=True
+        ["git", "commit", "-m", "initial"], cwd=layer, capture_output=True, check=True
+    )
+    subprocess.run(
+        ["git", "branch", "-M", "wrynose-next"],
+        cwd=layer,
+        capture_output=True,
+        check=True,
     )
 
     return layer
@@ -71,15 +81,26 @@ def git_layer_sha256(tmp_path):
 
     subprocess.run(["git", "init"], cwd=layer, capture_output=True, check=True)
     subprocess.run(
-        ["git", "config", "user.email", "test@test.com"], cwd=layer, capture_output=True, check=True
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=layer,
+        capture_output=True,
+        check=True,
     )
     subprocess.run(
-        ["git", "config", "user.name", "Test"], cwd=layer, capture_output=True, check=True
+        ["git", "config", "user.name", "Test"],
+        cwd=layer,
+        capture_output=True,
+        check=True,
     )
     subprocess.run(["git", "add", "--all"], cwd=layer, capture_output=True, check=True)
-    subprocess.run(["git", "commit", "-m", "initial"], cwd=layer, capture_output=True, check=True)
     subprocess.run(
-        ["git", "branch", "-M", "scarthgap-next"], cwd=layer, capture_output=True, check=True
+        ["git", "commit", "-m", "initial"], cwd=layer, capture_output=True, check=True
+    )
+    subprocess.run(
+        ["git", "branch", "-M", "scarthgap-next"],
+        cwd=layer,
+        capture_output=True,
+        check=True,
     )
 
     return layer
@@ -155,7 +176,9 @@ class TestBackport:
         assert result.branch_name == "backport/python3-botocore_1.43.55_to_wrynose-next"
 
         # Verify the file was renamed
-        new_file = git_layer / "recipes-devtools" / "python" / "python3-botocore_1.43.55.bb"
+        new_file = (
+            git_layer / "recipes-devtools" / "python" / "python3-botocore_1.43.55.bb"
+        )
         assert new_file.exists()
 
         # Verify SRCREV was updated
@@ -164,7 +187,9 @@ class TestBackport:
         assert "oldoldold" not in content
 
         # Verify old file is gone
-        old_file = git_layer / "recipes-devtools" / "python" / "python3-botocore_1.43.19.bb"
+        old_file = (
+            git_layer / "recipes-devtools" / "python" / "python3-botocore_1.43.19.bb"
+        )
         assert not old_file.exists()
 
     def test_sha256sum_backport(self, git_layer_sha256):
@@ -195,8 +220,14 @@ class TestBackport:
 
         # Verify sha256sums were updated
         content = new_file.read_text()
-        assert "1d03a3bd5091728492d92f0ef341aca7d8885ece9a150119558f3e3d62b58745" in content
-        assert "90a07c1c693ac9333a8a6ec79432f0d13c0564fec6617b0222d43f86858f65b8" in content
+        assert (
+            "1d03a3bd5091728492d92f0ef341aca7d8885ece9a150119558f3e3d62b58745"
+            in content
+        )
+        assert (
+            "90a07c1c693ac9333a8a6ec79432f0d13c0564fec6617b0222d43f86858f65b8"
+            in content
+        )
         assert "aaaa1111" not in content
         assert "bbbb2222" not in content
 
@@ -241,7 +272,9 @@ class TestParseUpgradeCommit:
         new_file.write_text(content)
         old_file.unlink()
 
-        subprocess.run(["git", "add", "--all"], cwd=git_layer, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "add", "--all"], cwd=git_layer, capture_output=True, check=True
+        )
         subprocess.run(
             ["git", "commit", "-m", "python3-botocore: upgrade 1.43.19 -> 1.43.20"],
             cwd=git_layer,

--- a/backporter/tests/test_backporter.py
+++ b/backporter/tests/test_backporter.py
@@ -1,0 +1,261 @@
+"""Tests for the backporter tool."""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from backporter.core import (
+    BackportInput,
+    backport,
+    find_recipe_file,
+    get_recipe_version,
+    update_sha256sums,
+    update_srcrev,
+)
+from backporter.parser import parse_upgrade_commit
+
+
+@pytest.fixture
+def git_layer(tmp_path):
+    """Create a minimal git repo with a recipe file."""
+    layer = tmp_path / "meta-aws"
+    recipes_dir = layer / "recipes-devtools" / "python"
+    recipes_dir.mkdir(parents=True)
+
+    # Create a recipe file
+    recipe_file = recipes_dir / "python3-botocore_1.43.19.bb"
+    recipe_file.write_text(
+        'SUMMARY = "python3 botocore"\n'
+        'DESCRIPTION = "The low-level, core functionality of boto3."\n'
+        'SRC_URI = "git://github.com/boto/botocore.git;protocol=https;branch=master"\n'
+        'SRCREV = "oldoldoldoldoldoldoldoldoldoldoldoldold0"\n'
+        "inherit setuptools3\n"
+    )
+
+    # Initialize git repo
+    subprocess.run(["git", "init"], cwd=layer, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"], cwd=layer, capture_output=True, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=layer, capture_output=True, check=True
+    )
+    subprocess.run(["git", "add", "--all"], cwd=layer, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"], cwd=layer, capture_output=True, check=True
+    )
+    subprocess.run(
+        ["git", "branch", "-M", "wrynose-next"], cwd=layer, capture_output=True, check=True
+    )
+
+    return layer
+
+
+@pytest.fixture
+def git_layer_sha256(tmp_path):
+    """Create a minimal git repo with a sha256sum-based recipe."""
+    layer = tmp_path / "meta-aws"
+    recipes_dir = layer / "recipes-devtools" / "amazon-corretto"
+    recipes_dir.mkdir(parents=True)
+
+    recipe_file = recipes_dir / "corretto-21-bin_21.0.10.9.1.bb"
+    recipe_file.write_text(
+        'SUMMARY = "Amazon Corretto 21"\n'
+        'SRC_URI:append:aarch64 = " https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-linux-aarch64.tar.gz;name=aarch64"\n'
+        'SRC_URI:append:x86-64 = " https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-linux-x64.tar.gz;name=x86-64"\n'
+        'SRC_URI[x86-64.sha256sum] = "aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111"\n'
+        'SRC_URI[aarch64.sha256sum] = "bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222"\n'
+        "require corretto-bin-common.inc\n"
+    )
+
+    subprocess.run(["git", "init"], cwd=layer, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"], cwd=layer, capture_output=True, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=layer, capture_output=True, check=True
+    )
+    subprocess.run(["git", "add", "--all"], cwd=layer, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"], cwd=layer, capture_output=True, check=True
+    )
+    subprocess.run(
+        ["git", "branch", "-M", "scarthgap-next"], cwd=layer, capture_output=True, check=True
+    )
+
+    return layer
+
+
+class TestFindRecipeFile:
+    def test_finds_recipe(self, git_layer):
+        result = find_recipe_file(git_layer, "python3-botocore")
+        assert result is not None
+        assert result.name == "python3-botocore_1.43.19.bb"
+
+    def test_returns_none_for_missing_recipe(self, git_layer):
+        result = find_recipe_file(git_layer, "nonexistent-recipe")
+        assert result is None
+
+
+class TestGetRecipeVersion:
+    def test_extracts_version(self):
+        path = Path("python3-botocore_1.43.19.bb")
+        assert get_recipe_version(path) == "1.43.19"
+
+    def test_complex_version(self):
+        path = Path("corretto-21-bin_21.0.11.10.1.bb")
+        assert get_recipe_version(path) == "21.0.11.10.1"
+
+
+class TestUpdateSrcrev:
+    def test_replaces_srcrev(self):
+        content = 'SRCREV = "oldoldoldoldoldoldoldoldoldoldoldoldold0"\n'
+        result = update_srcrev(content, "newnewnewnewnewnewnewnewnewnewnewnewnewnew1")
+        assert 'SRCREV = "newnewnewnewnewnewnewnewnewnewnewnewnewnew1"' in result
+        assert "oldoldold" not in result
+
+    def test_no_srcrev(self):
+        content = "SUMMARY = \"test\"\n"
+        result = update_srcrev(content, "abc123")
+        assert result == content
+
+
+class TestUpdateSha256sums:
+    def test_replaces_sha256sums(self):
+        content = (
+            'SRC_URI[x86-64.sha256sum] = "aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111"\n'
+            'SRC_URI[aarch64.sha256sum] = "bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222"\n'
+        )
+        result = update_sha256sums(
+            content,
+            {
+                "x86-64": "cccc3333cccc3333cccc3333cccc3333cccc3333cccc3333cccc3333cccc3333",
+                "aarch64": "dddd4444dddd4444dddd4444dddd4444dddd4444dddd4444dddd4444dddd4444",
+            },
+        )
+        assert "cccc3333" in result
+        assert "dddd4444" in result
+        assert "aaaa1111" not in result
+        assert "bbbb2222" not in result
+
+
+class TestBackport:
+    def test_srcrev_backport(self, git_layer):
+        input = BackportInput(
+            recipe="python3-botocore",
+            version="1.43.55",
+            target_branch="wrynose-next",
+            srcrev="b71d5637f58df4bc61953b80902b3c040c7af889",
+        )
+
+        result = backport(git_layer, input)
+
+        assert result.success is True
+        assert result.old_version == "1.43.19"
+        assert result.new_version == "1.43.55"
+        assert result.branch_name == "backport/python3-botocore_1.43.55_to_wrynose-next"
+
+        # Verify the file was renamed
+        new_file = git_layer / "recipes-devtools" / "python" / "python3-botocore_1.43.55.bb"
+        assert new_file.exists()
+
+        # Verify SRCREV was updated
+        content = new_file.read_text()
+        assert "b71d5637f58df4bc61953b80902b3c040c7af889" in content
+        assert "oldoldold" not in content
+
+        # Verify old file is gone
+        old_file = git_layer / "recipes-devtools" / "python" / "python3-botocore_1.43.19.bb"
+        assert not old_file.exists()
+
+    def test_sha256sum_backport(self, git_layer_sha256):
+        input = BackportInput(
+            recipe="corretto-21-bin",
+            version="21.0.11.10.1",
+            target_branch="scarthgap-next",
+            sha256sums={
+                "x86-64": "1d03a3bd5091728492d92f0ef341aca7d8885ece9a150119558f3e3d62b58745",
+                "aarch64": "90a07c1c693ac9333a8a6ec79432f0d13c0564fec6617b0222d43f86858f65b8",
+            },
+        )
+
+        result = backport(git_layer_sha256, input)
+
+        assert result.success is True
+        assert result.old_version == "21.0.10.9.1"
+        assert result.new_version == "21.0.11.10.1"
+
+        # Verify file was renamed
+        new_file = (
+            git_layer_sha256
+            / "recipes-devtools"
+            / "amazon-corretto"
+            / "corretto-21-bin_21.0.11.10.1.bb"
+        )
+        assert new_file.exists()
+
+        # Verify sha256sums were updated
+        content = new_file.read_text()
+        assert "1d03a3bd5091728492d92f0ef341aca7d8885ece9a150119558f3e3d62b58745" in content
+        assert "90a07c1c693ac9333a8a6ec79432f0d13c0564fec6617b0222d43f86858f65b8" in content
+        assert "aaaa1111" not in content
+        assert "bbbb2222" not in content
+
+    def test_recipe_not_found(self, git_layer):
+        input = BackportInput(
+            recipe="nonexistent-recipe",
+            version="1.0.0",
+            target_branch="wrynose-next",
+            srcrev="abc123",
+        )
+
+        result = backport(git_layer, input)
+
+        assert result.success is False
+        assert "not found" in result.message.lower()
+
+    def test_already_at_version(self, git_layer):
+        input = BackportInput(
+            recipe="python3-botocore",
+            version="1.43.19",
+            target_branch="wrynose-next",
+            srcrev="abc123",
+        )
+
+        result = backport(git_layer, input)
+
+        assert result.success is False
+        assert "already at version" in result.message.lower()
+
+
+class TestParseUpgradeCommit:
+    def test_parses_srcrev_commit(self, git_layer):
+        # Create a commit that looks like an upgrade
+        recipes_dir = git_layer / "recipes-devtools" / "python"
+        old_file = recipes_dir / "python3-botocore_1.43.19.bb"
+        new_file = recipes_dir / "python3-botocore_1.43.20.bb"
+
+        content = old_file.read_text().replace(
+            "oldoldoldoldoldoldoldoldoldoldoldoldold0",
+            "aabbccddaabbccddaabbccddaabbccddaabbccdd",
+        )
+        new_file.write_text(content)
+        old_file.unlink()
+
+        subprocess.run(["git", "add", "--all"], cwd=git_layer, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "python3-botocore: upgrade 1.43.19 -> 1.43.20"],
+            cwd=git_layer,
+            capture_output=True,
+            check=True,
+        )
+
+        result = parse_upgrade_commit(git_layer, "HEAD")
+
+        assert result is not None
+        assert result["recipe"] == "python3-botocore"
+        assert result["version"] == "1.43.20"
+        assert result["old_version"] == "1.43.19"
+        assert result["srcrev"] == "aabbccddaabbccddaabbccddaabbccddaabbccdd"

--- a/scripts/scrape_meta_aws.py
+++ b/scripts/scrape_meta_aws.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import json
-import os
 import re
 import subprocess
 import sys
@@ -39,25 +38,22 @@ DEPRECATED_BRANCHES = {"kirkstone"}
 def get_recipes_from_git(repo_path, branch="master"):
     """Extract recipe versions from git repository with category and path info"""
     recipes = {}
-    
+
     # Checkout the branch
     try:
         subprocess.run(
-            ["git", "checkout", branch],
-            cwd=repo_path,
-            capture_output=True,
-            check=True
+            ["git", "checkout", branch], cwd=repo_path, capture_output=True, check=True
         )
     except subprocess.CalledProcessError:
         return recipes
-    
+
     # Find all .bb files in all recipes-* directories
     for recipes_dir in Path(repo_path).glob("recipes-*"):
         if not recipes_dir.is_dir():
             continue
-        
+
         category = recipes_dir.name  # e.g., "recipes-iot"
-        
+
         for bb_file in recipes_dir.rglob("*.bb"):
             # Extract recipe name and version from filename
             # Format: recipename_version.bb
@@ -65,23 +61,23 @@ def get_recipes_from_git(repo_path, branch="master"):
             if match:
                 recipe_name = match.group(1)
                 recipe_version = match.group(2)
-                
+
                 # Get subdirectory path relative to recipes-* directory
                 subdir = bb_file.parent.relative_to(recipes_dir)
-                
+
                 if recipe_version != "git":
                     recipes[recipe_name] = {
                         "version": recipe_version,
                         "category": category,
-                        "path": str(subdir)
+                        "path": str(subdir),
                     }
                 else:
                     recipes[recipe_name] = {
                         "version": "git",
                         "category": category,
-                        "path": str(subdir)
+                        "path": str(subdir),
                     }
-    
+
     return recipes
 
 
@@ -92,7 +88,7 @@ def get_status_indicator(master_ver, next_ver):
         master_ver = master_ver.get("version", "-")
     if isinstance(next_ver, dict):
         next_ver = next_ver.get("version", "-")
-    
+
     if master_ver == "-" or master_ver == "":
         return '<span style="color: #999;">-</span>'
     if next_ver == "-" or next_ver == "":
@@ -113,10 +109,14 @@ def color_version_html(ver, versions):
     # Handle dict format
     if isinstance(ver, dict):
         ver = ver.get("version", "-")
-    
+
     if ver == "-" or ver == "":
         return ver
-    valid = [v.get("version", "-") if isinstance(v, dict) else v for v in versions if (v.get("version", "-") if isinstance(v, dict) else v) not in ["-", ""]]
+    valid = [
+        v.get("version", "-") if isinstance(v, dict) else v
+        for v in versions
+        if (v.get("version", "-") if isinstance(v, dict) else v) not in ["-", ""]
+    ]
     if len(set(valid)) <= 1:
         return ver
     try:
@@ -135,42 +135,58 @@ def generate_detail_page(branch, all_data, all_recipes, updated, version_pins=No
     """Generate detailed version page for a specific branch"""
     master_recipes = all_data.get(branch, {})
     next_recipes = all_data.get(f"{branch}-next", {})
-    
-    html = ['<!DOCTYPE html>', '<html lang="en">', '<head>',
-            '    <meta charset="UTF-8">',
-            '    <meta name="viewport" content="width=device-width, initial-scale=1.0">',
-            f'    <title>meta-aws Recipe Versions - {branch}</title>',
-            '    <link rel="stylesheet" href="style.css">',
-            '    <style>',
-            '        .version-latest { font-weight: bold; color: #28a745; }',
-            '        .version-oldest { color: #dc3545; }',
-            '        .version-mid { color: #ffc107; }',
-            '        .next-col { background: #f8f9fa; font-style: italic; }',
-            '        .report-header { background: white; padding: 1.5rem; margin-bottom: 1rem; border-radius: 8px; }',
-            '        .back-link { color: #ff9900; text-decoration: none; }',
-            '        .back-link:hover { text-decoration: underline; }',
-            '        .category-header { background: #f0f0f0; font-weight: bold; }',
-            '        .recipe-path { font-size: 0.75em; color: #666; font-style: italic; }',
-            '    </style>',
-            '</head>', '<body>', '    <header>',
-            '        <h1>meta-aws Recipe Versions</h1>',
-            f'        <h2>{branch} vs {branch}-next</h2>',
-            '    </header>', '    <main>',
-            '        <div class="report-header">',
-            '            <p><a href="recipe-versions.html" class="back-link">← Back to Overview</a></p>',
-            f'            <p><strong>Last Updated:</strong> {updated}</p>',]
+
+    html = [
+        "<!DOCTYPE html>",
+        '<html lang="en">',
+        "<head>",
+        '    <meta charset="UTF-8">',
+        '    <meta name="viewport" content="width=device-width, initial-scale=1.0">',
+        f"    <title>meta-aws Recipe Versions - {branch}</title>",
+        '    <link rel="stylesheet" href="style.css">',
+        "    <style>",
+        "        .version-latest { font-weight: bold; color: #28a745; }",
+        "        .version-oldest { color: #dc3545; }",
+        "        .version-mid { color: #ffc107; }",
+        "        .next-col { background: #f8f9fa; font-style: italic; }",
+        "        .report-header { background: white; padding: 1.5rem; margin-bottom: 1rem; border-radius: 8px; }",
+        "        .back-link { color: #ff9900; text-decoration: none; }",
+        "        .back-link:hover { text-decoration: underline; }",
+        "        .category-header { background: #f0f0f0; font-weight: bold; }",
+        "        .recipe-path { font-size: 0.75em; color: #666; font-style: italic; }",
+        "    </style>",
+        "</head>",
+        "<body>",
+        "    <header>",
+        "        <h1>meta-aws Recipe Versions</h1>",
+        f"        <h2>{branch} vs {branch}-next</h2>",
+        "    </header>",
+        "    <main>",
+        '        <div class="report-header">',
+        '            <p><a href="recipe-versions.html" class="back-link">← Back to Overview</a></p>',
+        f"            <p><strong>Last Updated:</strong> {updated}</p>",
+    ]
     if branch in DEPRECATED_BRANCHES:
-        html.append('            <p style="color: #dc3545; font-weight: bold;">⛔ This branch is deprecated. No further updates will be made.</p>')
-    html.extend([
-            f'            <p><strong>Comparing:</strong> {branch} branch vs {branch}-next branch from meta-aws git repository</p>',
-            '            <p><strong>Legend:</strong> 🟢 Newest version | 🟡 Mid version | 🔴 Oldest version (comparing branch vs branch-next)</p>',
-            '        </div>',
-            '        <table>', '            <thead>', '                <tr>',
-            '                    <th>Recipe</th>',
-            f'                    <th>{branch}</th>',
+        html.append(
+            '            <p style="color: #dc3545; font-weight: bold;">⛔ This branch is deprecated. No further updates will be made.</p>'
+        )
+    html.extend(
+        [
+            f"            <p><strong>Comparing:</strong> {branch} branch vs {branch}-next branch from meta-aws git repository</p>",
+            "            <p><strong>Legend:</strong> 🟢 Newest version | 🟡 Mid version | 🔴 Oldest version (comparing branch vs branch-next)</p>",
+            "        </div>",
+            "        <table>",
+            "            <thead>",
+            "                <tr>",
+            "                    <th>Recipe</th>",
+            f"                    <th>{branch}</th>",
             f'                    <th class="next-col">{branch}-next</th>',
-            '                </tr>', '            </thead>', '            <tbody>'])
-    
+            "                </tr>",
+            "            </thead>",
+            "            <tbody>",
+        ]
+    )
+
     # Group recipes by category
     recipes_by_category = {}
     for recipe in all_recipes:
@@ -180,44 +196,64 @@ def generate_detail_page(branch, all_data, all_recipes, updated, version_pins=No
             if category not in recipes_by_category:
                 recipes_by_category[category] = []
             recipes_by_category[category].append(recipe)
-    
+
     # Generate rows grouped by category
     for category in sorted(recipes_by_category.keys()):
         # Category header
         html.append(f'                <tr class="category-header">')
         html.append(f'                    <td colspan="3">{category}</td>')
-        html.append('                </tr>')
-        
+        html.append("                </tr>")
+
         for recipe in sorted(recipes_by_category[category]):
             master_info = master_recipes.get(recipe, {})
             next_info = next_recipes.get(recipe, {})
-            
-            master_ver = master_info.get("version", "-") if isinstance(master_info, dict) else master_info
-            next_ver = next_info.get("version", "-") if isinstance(next_info, dict) else next_info
-            recipe_path = master_info.get("path", "") if isinstance(master_info, dict) else ""
-            
+
+            master_ver = (
+                master_info.get("version", "-")
+                if isinstance(master_info, dict)
+                else master_info
+            )
+            next_ver = (
+                next_info.get("version", "-")
+                if isinstance(next_info, dict)
+                else next_info
+            )
+            recipe_path = (
+                master_info.get("path", "") if isinstance(master_info, dict) else ""
+            )
+
             versions = [master_ver, next_ver]
             colored = [color_version_html(v, versions) for v in versions]
-            
+
             html.append(f'                <tr id="{recipe}">')
-            recipe_display = f'<strong>{recipe}</strong>'
+            recipe_display = f"<strong>{recipe}</strong>"
             if recipe_path and recipe_path != ".":
                 recipe_display += f'<br><span class="recipe-path">{recipe_path}</span>'
-            html.append(f'                    <td>{recipe_display}</td>')
-            html.append(f'                    <td>{colored[0]}</td>')
+            html.append(f"                    <td>{recipe_display}</td>")
+            html.append(f"                    <td>{colored[0]}</td>")
             html.append(f'                    <td class="next-col">{colored[1]}</td>')
-            html.append('                </tr>')
+            html.append("                </tr>")
             if version_pins:
                 pin_note = version_pins.get(branch, {}).get(recipe, {})
                 if isinstance(pin_note, dict) and pin_note.get("reason"):
-                    html.append(f'                <tr><td colspan="3" style="font-size:0.85em;color:#856404;background:#fff3cd;padding:4px 12px;">📌 {pin_note["reason"]}</td></tr>')
-    
-    html.extend(['            </tbody>', '        </table>', '    </main>',
-                 '    <footer>',
-                 '        <p>Generated by <a href="https://github.com/aws4embeddedlinux/meta-aws-ci">meta-aws-ci</a></p>',
-                 '    </footer>', '</body>', '</html>'])
-    
-    return '\n'.join(html)
+                    html.append(
+                        f'                <tr><td colspan="3" style="font-size:0.85em;color:#856404;background:#fff3cd;padding:4px 12px;">📌 {pin_note["reason"]}</td></tr>'
+                    )
+
+    html.extend(
+        [
+            "            </tbody>",
+            "        </table>",
+            "    </main>",
+            "    <footer>",
+            '        <p>Generated by <a href="https://github.com/aws4embeddedlinux/meta-aws-ci">meta-aws-ci</a></p>',
+            "    </footer>",
+            "</body>",
+            "</html>",
+        ]
+    )
+
+    return "\n".join(html)
 
 
 def main():
@@ -231,19 +267,28 @@ def main():
     version_pins = {}
     if pins_file.exists():
         version_pins = json.loads(pins_file.read_text())
-        print(f"Loaded version pins for: {', '.join(version_pins.keys())}", file=sys.stderr)
+        print(
+            f"Loaded version pins for: {', '.join(version_pins.keys())}",
+            file=sys.stderr,
+        )
 
     all_data = {}
-    
+
     # Clone meta-aws repository to temporary directory
     with tempfile.TemporaryDirectory() as tmpdir:
         repo_path = Path(tmpdir) / "meta-aws"
         print(f"Cloning meta-aws repository...", file=sys.stderr)
         subprocess.run(
-            ["git", "clone", "--quiet", "https://github.com/aws4embeddedlinux/meta-aws.git", str(repo_path)],
-            check=True
+            [
+                "git",
+                "clone",
+                "--quiet",
+                "https://github.com/aws4embeddedlinux/meta-aws.git",
+                str(repo_path),
+            ],
+            check=True,
         )
-        
+
         for branch in branches:
             for suffix in ["", "-next"]:
                 branch_name = f"{branch}{suffix}"
@@ -268,7 +313,9 @@ def main():
     docs_dir = Path("docs")
     for branch in branches:
         if branch in all_data:
-            detail_html = generate_detail_page(branch, all_data, all_recipes, updated, version_pins)
+            detail_html = generate_detail_page(
+                branch, all_data, all_recipes, updated, version_pins
+            )
             detail_file = docs_dir / f"recipe-versions-{branch}.html"
             detail_file.write_text(detail_html)
             print(f"Generated {detail_file}", file=sys.stderr)
@@ -291,7 +338,9 @@ def main():
     print("        .back-link { color: #ff9900; text-decoration: none; }")
     print("        .back-link:hover { text-decoration: underline; }")
     print("        .category-header { background: #f0f0f0; font-weight: bold; }")
-    print("        .recipe-path { font-size: 0.75em; color: #666; font-style: italic; }")
+    print(
+        "        .recipe-path { font-size: 0.75em; color: #666; font-style: italic; }"
+    )
     print("    </style>")
     print("</head>")
     print("<body>")
@@ -341,23 +390,23 @@ def main():
             recipe_info = all_data.get(branch, {}).get(recipe)
             if recipe_info:
                 break
-        
+
         if recipe_info and isinstance(recipe_info, dict):
             category = recipe_info.get("category", "unknown")
             if category not in recipes_by_category:
                 recipes_by_category[category] = []
             recipes_by_category[category].append(recipe)
-    
+
     # Generate rows grouped by category
     for category in sorted(recipes_by_category.keys()):
         # Category header
         print(f'                <tr class="category-header">')
         print(f'                    <td colspan="{len(branches) + 1}">{category}</td>')
-        print('                </tr>')
-        
+        print("                </tr>")
+
         for recipe in sorted(recipes_by_category[category]):
             print("                <tr>")
-            
+
             # Get recipe path from first available branch
             recipe_path = ""
             for branch in branches:
@@ -365,27 +414,39 @@ def main():
                 if recipe_info and isinstance(recipe_info, dict):
                     recipe_path = recipe_info.get("path", "")
                     break
-            
+
             recipe_display = f"<strong>{recipe}</strong>"
             if recipe_path and recipe_path != ".":
                 recipe_display += f'<br><span class="recipe-path">{recipe_path}</span>'
-            
+
             print(f"                    <td>{recipe_display}</td>")
-            
+
             for branch in branches:
                 master_info = all_data.get(branch, {}).get(recipe, {})
                 next_info = all_data.get(f"{branch}-next", {}).get(recipe, {})
-                
-                master_ver = master_info.get("version", "-") if isinstance(master_info, dict) else master_info if master_info else "-"
-                next_ver = next_info.get("version", "-") if isinstance(next_info, dict) else next_info if next_info else master_ver
-                
+
+                master_ver = (
+                    master_info.get("version", "-")
+                    if isinstance(master_info, dict)
+                    else master_info if master_info else "-"
+                )
+                next_ver = (
+                    next_info.get("version", "-")
+                    if isinstance(next_info, dict)
+                    else next_info if next_info else master_ver
+                )
+
                 status = get_status_indicator(master_ver, next_ver)
                 pin_note = version_pins.get(branch, {}).get(recipe, {})
                 if isinstance(pin_note, dict) and pin_note.get("reason"):
-                    reason = pin_note["reason"].replace('"', '&quot;')
-                    print(f'                    <td class="status-cell"><a href="recipe-versions-{branch}.html#{recipe}" title="📌 {reason}">{status} 📌</a></td>')
+                    reason = pin_note["reason"].replace('"', "&quot;")
+                    print(
+                        f'                    <td class="status-cell"><a href="recipe-versions-{branch}.html#{recipe}" title="📌 {reason}">{status} 📌</a></td>'
+                    )
                 else:
-                    print(f'                    <td class="status-cell"><a href="recipe-versions-{branch}.html#{recipe}">{status}</a></td>')
+                    print(
+                        f'                    <td class="status-cell"><a href="recipe-versions-{branch}.html#{recipe}">{status}</a></td>'
+                    )
             print("                </tr>")
 
     print("            </tbody>")


### PR DESCRIPTION
## Summary

Adds a new `backporter` tool that replaces the cherry-pick-based backport approach (`korthout/backport-action`) which produced draft PRs with unresolvable merge conflicts.

## Problem

The current `auto-backport.yml` uses `git cherry-pick` to backport version upgrades from master-next to release branches. This fails because release branches are at different versions — e.g., cherry-picking a `1.43.53 → 1.43.55` delta onto a branch at `1.43.19` produces conflicts. Result: 150+ dead draft PRs with conflict markers.

## Solution

The backporter performs clean, independent version upgrades:
1. Finds the current recipe `.bb` file on the target branch
2. `git mv` to the new version filename
3. Updates SRCREV or SRC_URI sha256sum hashes
4. Commits

Handles both:
- **SRCREV-based recipes** (git sources): aws-crt-cpp, python3-botocore, etc.
- **sha256sum-based recipes** (binary downloads): corretto-*-bin, firecracker-bin, etc.

Gracefully skips if the recipe doesn't exist on the target branch or is already at the target version.

## Contents

```
backporter/
├── pyproject.toml
├── auto-backport.yml           # Replacement workflow for meta-aws
├── backporter/
│   ├── __init__.py
│   ├── core.py                 # git mv + hash update logic
│   ├── cli.py                  # CLI: upgrade + parse-commit
│   └── parser.py               # Extract recipe/version/hashes from commits
└── tests/
    └── test_backporter.py      # 12 unit tests
```

## Usage

```bash
# Parse a merged commit to extract upgrade info
backporter parse-commit --commit HEAD --layer-path ./meta-aws

# Backport a SRCREV-based recipe
backporter upgrade --recipe python3-botocore --version 1.43.55 \
    --srcrev b71d5637... --target-branch wrynose-next --layer-path ./meta-aws

# Backport a sha256sum-based recipe
backporter upgrade --recipe corretto-25-bin --version 25.0.4.7.1 \
    --sha256sum "x86-64=1d03a3bd..." --sha256sum "aarch64=90a07c1c..." \
    --target-branch scarthgap-next --layer-path ./meta-aws
```

## Testing

- 12 unit tests passing
- Verified against real meta-aws repo (python3-botocore on wrynose-next, corretto-25-bin on scarthgap-next)
- Diffs are structurally identical to auto-upgrader output