### PR TITLE
fix: prevent accidental gitlink staging in backporter and upgrader

### DIFF
--- a/auto-upgrader/upgrader/updates.py
+++ b/auto-upgrader/upgrader/updates.py
@@ -162,9 +162,16 @@ def update(layer_path: Path, target_branch: str) -> None:
             result["fail"].append(upgrade)
             continue
 
-        # Commit upgrade
-        run(f"git -C {layer_path} add --all")
-        run(f'git -C {layer_path} commit -a -m "{commit_msg}"')
+        # Commit upgrade — stage only layer content, not unrelated checkouts
+        # that may appear in the working tree (e.g. CI tool repos). Using
+        # pathspecs for known layer directories prevents accidental gitlink
+        # staging (see meta-aws#16495).
+        run(f"git -C {layer_path} add -u")  # stage modifications/deletions to tracked files
+        run(
+            f"git -C {layer_path} add"
+            f" -- recipes-* classes conf dynamic-layers images .github"
+        )  # stage new files only in known layer directories
+        run(f'git -C {layer_path} commit -m "{commit_msg}"')
 
         with open(BRANCH_FILE, "a") as f:
             f.write(new_branch + "\n")

--- a/backporter/auto-backport.yml
+++ b/backporter/auto-backport.yml
@@ -29,6 +29,12 @@ jobs:
           ref: master
           path: ci
 
+      - name: Exclude ci/ from git tracking
+        run: |
+          # The ci/ checkout lives inside the meta-aws working tree.
+          # Ensure git never stages it as a gitlink (fixes #16495).
+          echo "ci/" >> .git/info/exclude
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/backporter/backporter/core.py
+++ b/backporter/backporter/core.py
@@ -293,8 +293,11 @@ def backport(layer_path: Path, input: BackportInput) -> BackportResult:
     # Write updated content
     new_path.write_text(content)
 
-    # Stage and commit
-    run_git(["add", "--all"], cwd=layer_path)
+    # Stage only the specific recipe files that changed (the git mv already
+    # staged the rename; we just need to stage the content update to the new file).
+    # Avoid "git add --all" which can accidentally stage unrelated files such as
+    # CI tool checkouts that appear inside the working tree (see #16495).
+    run_git(["add", str(new_path.relative_to(layer_path))], cwd=layer_path)
 
     commit_msg = f"{recipe}: upgrade {old_version} -> {new_version}"
     try:


### PR DESCRIPTION
## Problem

The auto-backport workflow checks out `meta-aws-ci` into a `ci/` directory inside the `meta-aws` working tree. Both the backporter (`core.py`) and upgrader (`updates.py`) used `git add --all`, which staged this checkout as a submodule reference (mode 160000) without a corresponding `.gitmodules` entry — creating an orphaned gitlink.

This broke downstream users who recursively update submodules:
```
fatal: No url found for submodule path 'meta-external/meta-aws/ci' in .gitmodules
```

## Fix

1. **backporter/core.py**: Replace `git add --all` with targeted staging of only the renamed recipe file
2. **auto-upgrader/updates.py**: Replace `git add --all` with `git add -u` (tracked changes) + pathspec-limited add for known layer directories
3. **auto-backport.yml**: Add `.git/info/exclude` step to exclude `ci/` as defense-in-depth

## Testing

- All 12 backporter unit tests pass
- Auto-upgrader test failure is pre-existing (Python 3.13 asyncio incompatibility in proc.py, unrelated)

Fixes aws4embeddedlinux/meta-aws#16495